### PR TITLE
Update Tle5012b.h

### DIFF
--- a/src/Tle5012b.h
+++ b/src/Tle5012b.h
@@ -116,10 +116,10 @@
 #define GET_BIT_14_4				0x7FF0
 
 //default speed of SPI transfer
-#define SPEED					500000
+#define SPEED					8000000
 
 //delay for the update
-#define DELAYuS 				100
+#define DELAYuS 				10
 
 //dummy variable used for receive. Each time this is sent, it is for the purposes of receiving using SPI transfer.
 #define DUMMY 					0xFFFF


### PR DESCRIPTION
The datasheet advertises 8mbit SPI speed. With your library default settings getanglevalue takes almost 300us to read actual angle, which is quiet slow for any fast enough positioning device. I tried with speed= 8000000 and I get 0 value readings. Most I could get with my uC ( it supports 80mhz SPI easily) speed = 2500000. When I lower delay to 5uS I get about 50us getangle read time. Why so? And why is this delay function there?