### PR TITLE
Fixed the bug in the getAngleSpeed function

### DIFF
--- a/src/corelib/TLE5012b.cpp
+++ b/src/corelib/TLE5012b.cpp
@@ -483,7 +483,7 @@ errorTypes Tle5012b::getAngleSpeed(double &finalAngleSpeed)
 }
 errorTypes Tle5012b::getAngleSpeed(double &finalAngleSpeed, int16_t &rawSpeed, updTypes upd, safetyTypes safe)
 {
-	int8_t numOfData = 0x5;
+	int8_t numOfData = 0x6;
 	uint16_t rawData[numOfData] = {};
 
 	errorTypes status = readMoreRegisters(reg.REG_ASPD + numOfData, rawData, upd, safe);


### PR DESCRIPTION
Fixed the bug inside the getAngleSpeed function mentioned in https://github.com/Infineon/TLE5012-Magnetic-Angle-Sensor/issues/15.

Was already tested on hardware by @9Volts9er.
